### PR TITLE
Fix version file compatibility (KSP 1.10)

### DIFF
--- a/GameData/ThrottleControlledAvionics/ThrottleControlledAvionics.version
+++ b/GameData/ThrottleControlledAvionics/ThrottleControlledAvionics.version
@@ -13,7 +13,7 @@
     "KSP_VERSION_MIN":
      {
          "MAJOR":1,
-         "MINOR":9,
+         "MINOR":10,
          "PATCH":0
      },
     "KSP_VERSION_MAX":


### PR DESCRIPTION
This is allista/AT_Utils#24 for ThrottleControlledAvionics.

![image](https://user-images.githubusercontent.com/1559108/92968739-3371de80-f46b-11ea-9c5e-a8c052b78268.png)

The version file indicates that 3.7.2 is compatible with KSP 1.9, and this has propagated into CKAN.
Now this is fixed; 3.7.2 will be marked as 1.10-only within 30 minutes after merge, and 3.7.1 will be fixed manually in a separate pull request in the CKAN metadata repo.

Fixes KSP-CKAN/NetKAN#8140.

Tagging @allista to ensure GitHub notifications happen.